### PR TITLE
fix compilation on openssl 1.1

### DIFF
--- a/dnskey.c
+++ b/dnskey.c
@@ -156,6 +156,7 @@ int dnskey_build_pkey(struct rr_dnskey *rr)
 		unsigned int e_bytes;
 		unsigned char *pk;
 		int l;
+		BIGNUM *n, *e;
 
 		rsa = RSA_new();
 		if (!rsa)
@@ -176,11 +177,12 @@ int dnskey_build_pkey(struct rr_dnskey *rr)
 		if (l < e_bytes) /* public key is too short */
 			goto done;
 
-		rsa->e = BN_bin2bn(pk, e_bytes, NULL);
+		e = BN_bin2bn(pk, e_bytes, NULL);
 		pk += e_bytes;
 		l -= e_bytes;
 
-		rsa->n = BN_bin2bn(pk, l, NULL);
+		n = BN_bin2bn(pk, l, NULL);
+		RSA_set0_key(rsa, n, e, NULL);
 
 		pkey = EVP_PKEY_new();
 		if (!pkey)

--- a/nsec3checks.c
+++ b/nsec3checks.c
@@ -28,7 +28,7 @@
 static struct binary_data name2hash(char *name, struct rr *param)
 {
     struct rr_nsec3param *p = (struct rr_nsec3param *)param;
-	EVP_MD_CTX ctx;
+	EVP_MD_CTX *ctx;
 	unsigned char md0[EVP_MAX_MD_SIZE];
 	unsigned char md1[EVP_MAX_MD_SIZE];
 	unsigned char *md[2];
@@ -45,22 +45,23 @@ static struct binary_data name2hash(char *name, struct rr *param)
 
 	/* XXX Maybe use Init_ex and Final_ex for speed? */
 
-	EVP_MD_CTX_init(&ctx);
-	if (EVP_DigestInit(&ctx, EVP_sha1()) != 1)
+	ctx = EVP_MD_CTX_new();
+	if (EVP_DigestInit(ctx, EVP_sha1()) != 1)
 		return r;
-	digest_size = EVP_MD_CTX_size(&ctx);
-	EVP_DigestUpdate(&ctx, wire_name.data, wire_name.length);
-	EVP_DigestUpdate(&ctx, p->salt.data, p->salt.length);
-	EVP_DigestFinal(&ctx, md[mdi], NULL);
+	digest_size = EVP_MD_CTX_size(ctx);
+	EVP_DigestUpdate(ctx, wire_name.data, wire_name.length);
+	EVP_DigestUpdate(ctx, p->salt.data, p->salt.length);
+	EVP_DigestFinal(ctx, md[mdi], NULL);
 
 	for (i = 0; i < p->iterations; i++) {
-		if (EVP_DigestInit(&ctx, EVP_sha1()) != 1)
+		if (EVP_DigestInit(ctx, EVP_sha1()) != 1)
 			return r;
-		EVP_DigestUpdate(&ctx, md[mdi], digest_size);
+		EVP_DigestUpdate(ctx, md[mdi], digest_size);
 		mdi = (mdi + 1) % 2;
-		EVP_DigestUpdate(&ctx, p->salt.data, p->salt.length);
-		EVP_DigestFinal(&ctx, md[mdi], NULL);
+		EVP_DigestUpdate(ctx, p->salt.data, p->salt.length);
+		EVP_DigestFinal(ctx, md[mdi], NULL);
 	}
+	EVP_MD_CTX_free(ctx);
 
 	r.length = digest_size;
 	r.data = getmem(digest_size);

--- a/rrsig.c
+++ b/rrsig.c
@@ -27,7 +27,7 @@
 struct verification_data
 {
 	struct verification_data *next;
-	EVP_MD_CTX ctx;
+	EVP_MD_CTX *ctx;
 	struct rr_dnskey *key;
 	struct rr_rrsig *rr;
 	int ok;
@@ -97,10 +97,13 @@ static struct rr* rrsig_parse(char *name, long ttl, int type, char *s)
 		 * representation (r || s) into OpenSSL ASN.1 DER format
 		 */
 		ECDSA_SIG *ecdsa_sig = ECDSA_SIG_new();
+		BIGNUM *r, *s;
 		int l = sig.length / 2;
-		if ((BN_bin2bn((unsigned char *)sig.data, l, ecdsa_sig->r) == NULL) ||
-		    (BN_bin2bn(((unsigned char *)sig.data) + l, l, ecdsa_sig->s) == NULL))
+		r = BN_bin2bn((unsigned char *)sig.data, l, NULL);
+		s = BN_bin2bn((unsigned char *)sig.data + l, l, NULL);
+		if ((r == NULL) || (s == NULL))
 			return NULL;
+		ECDSA_SIG_set0(ecdsa_sig, r, s);
 		sig.length = i2d_ECDSA_SIG(ecdsa_sig, NULL);
 		sig.data = getmem(sig.length); /* reallocate larger mempool chunk */
 		unsigned char *sig_ptr = (unsigned char *)sig.data;
@@ -197,7 +200,7 @@ void *verification_thread(void *dummy)
 		if (d) {
 			int r;
 			d->next = NULL;
-			r = EVP_VerifyFinal(&d->ctx, (unsigned char *)d->rr->signature.data, d->rr->signature.length, d->key->pkey);
+			r = EVP_VerifyFinal(d->ctx, (unsigned char *)d->rr->signature.data, d->rr->signature.length, d->key->pkey);
 			if (r == 1) {
 				d->ok = 1;
 			} else {
@@ -249,7 +252,7 @@ static void schedule_verification(struct verification_data *d)
 	} else {
 		int r;
 		G.stats.signatures_verified++;
-		r = EVP_VerifyFinal(&d->ctx, (unsigned char *)d->rr->signature.data, d->rr->signature.length, d->key->pkey);
+		r = EVP_VerifyFinal(d->ctx, (unsigned char *)d->rr->signature.data, d->rr->signature.length, d->key->pkey);
 		if (r == 1) {
 			d->ok = 1;
 		} else {
@@ -267,29 +270,29 @@ static int verify_signature(struct verification_data *d, struct rr_set *signed_s
 	struct rr *signed_rr;
 	int i;
 
-	EVP_MD_CTX_init(&d->ctx);
+	d->ctx = EVP_MD_CTX_new();
 	switch (d->rr->algorithm) {
 	case ALG_DSA:
 	case ALG_RSASHA1:
 	case ALG_DSA_NSEC3_SHA1:
 	case ALG_RSASHA1_NSEC3_SHA1:
-		if (EVP_VerifyInit(&d->ctx, EVP_sha1()) != 1)
+		if (EVP_VerifyInit(d->ctx, EVP_sha1()) != 1)
 			return 0;
 		break;
 	case ALG_RSASHA256:
-		if (EVP_VerifyInit(&d->ctx, EVP_sha256()) != 1)
+		if (EVP_VerifyInit(d->ctx, EVP_sha256()) != 1)
 			return 0;
 		break;
 	case ALG_RSASHA512:
-		if (EVP_VerifyInit(&d->ctx, EVP_sha512()) != 1)
+		if (EVP_VerifyInit(d->ctx, EVP_sha512()) != 1)
 			return 0;
 		break;
 	case ALG_ECDSAP256SHA256:
-		if (EVP_VerifyInit(&d->ctx, EVP_sha256()) != 1)
+		if (EVP_VerifyInit(d->ctx, EVP_sha256()) != 1)
 			return 0;
 		break;
 	case ALG_ECDSAP384SHA384:
-		if (EVP_VerifyInit(&d->ctx, EVP_sha384()) != 1)
+		if (EVP_VerifyInit(d->ctx, EVP_sha384()) != 1)
 			return 0;
 		break;
 	default:
@@ -299,7 +302,7 @@ static int verify_signature(struct verification_data *d, struct rr_set *signed_s
 	chunk = rrsig_wirerdata_ex(&d->rr->rr, 0);
 	if (chunk.length < 0)
 		return 0;
-	EVP_VerifyUpdate(&d->ctx, chunk.data, chunk.length);
+	EVP_VerifyUpdate(d->ctx, chunk.data, chunk.length);
 
 	set = getmem_temp(sizeof(*set) * signed_set->count);
 
@@ -319,12 +322,12 @@ static int verify_signature(struct verification_data *d, struct rr_set *signed_s
 		chunk = name2wire_name(signed_set->named_rr->name);
 		if (chunk.length < 0)
 			return 0;
-		EVP_VerifyUpdate(&d->ctx, chunk.data, chunk.length);
-		b2 = htons(set[i].rr->rdtype);    EVP_VerifyUpdate(&d->ctx, &b2, 2);
-		b2 = htons(1);  /* class IN */   EVP_VerifyUpdate(&d->ctx, &b2, 2);
-		b4 = htonl(set[i].rr->ttl);       EVP_VerifyUpdate(&d->ctx, &b4, 4);
-		b2 = htons(set[i].wired.length); EVP_VerifyUpdate(&d->ctx, &b2, 2);
-		EVP_VerifyUpdate(&d->ctx, set[i].wired.data, set[i].wired.length);
+		EVP_VerifyUpdate(d->ctx, chunk.data, chunk.length);
+		b2 = htons(set[i].rr->rdtype);    EVP_VerifyUpdate(d->ctx, &b2, 2);
+		b2 = htons(1);  /* class IN */   EVP_VerifyUpdate(d->ctx, &b2, 2);
+		b4 = htonl(set[i].rr->ttl);       EVP_VerifyUpdate(d->ctx, &b4, 4);
+		b2 = htons(set[i].wired.length); EVP_VerifyUpdate(d->ctx, &b2, 2);
+		EVP_VerifyUpdate(d->ctx, set[i].wired.data, set[i].wired.length);
 	}
 
 	schedule_verification(d);
@@ -399,7 +402,7 @@ static void *rrsig_validate(struct rr *rrv)
 static pthread_mutex_t *lock_cs;
 static long *lock_count;
 
-static unsigned long pthreads_thread_id(void)
+unsigned long pthreads_thread_id(void)
 {
 	unsigned long ret;
 
@@ -407,7 +410,7 @@ static unsigned long pthreads_thread_id(void)
 	return(ret);
 }
 
-static void pthreads_locking_callback(int mode, int type, char *file, int line)
+void pthreads_locking_callback(int mode, int type, char *file, int line)
 {
 	if (mode & CRYPTO_LOCK) {
 		pthread_mutex_lock(&(lock_cs[type]));
@@ -471,6 +474,7 @@ void verify_all_keys(void)
 				if (k->to_verify[i].openssl_error != 0)
 					e = k->to_verify[i].openssl_error;
 			}
+			EVP_MD_CTX_free(k->to_verify[i].ctx);
 		}
 		if (!ok) {
 			struct named_rr *named_rr;


### PR DESCRIPTION
Mostly cosmetic changes, apart from the change to free the `ctx` in `rrsig.c`'s `verify_all_keys`. I'm pretty sure this is the correct place, but the threading and allocation code is quite weird.

All the tests pass.