### PR TITLE
The arguments to isxxxx() and family must give well-defined results.

### DIFF
--- a/base32hex.c
+++ b/base32hex.c
@@ -48,7 +48,7 @@ decode_base32hex(void *dest, char *src, size_t dstsize)
             v = *src - 'a' + 10;
         else if (*src >= '0' && *src <= '9')
             v = *src - '0';
-        else if (isspace(*src) || *src == '=') {
+        else if (isspace((unsigned char)*src) || *src == '=') {
             src++;
             continue;
         } else {

--- a/base64.c
+++ b/base64.c
@@ -39,7 +39,7 @@ decode_base64(void *dest, char *src, size_t dstsize)
             v = 62;
         else if (*src == '/')
             v = 63;
-        else if (isspace(*src) || *src == '=') {
+        else if (isspace((unsigned char)*src) || *src == '=') {
             src++;
             continue;
         } else {

--- a/carp.c
+++ b/carp.c
@@ -102,7 +102,7 @@ static char proggy[MAXPATHLEN];
 
 const char *thisprogname(void)
 {
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
     return getprogname();
 #elif defined(__APPLE__)
     return getprogname();

--- a/cert.c
+++ b/cert.c
@@ -29,7 +29,7 @@ static int extract_certificate_type(char **s, char *what)
     int type;
     char *str_type;
 
-    if (isdigit(**s)) {
+    if (isdigit((unsigned char)**s)) {
         type = extract_integer(s, what, NULL);
         if (type >= 1 && type <= 8)
             return type;
@@ -90,7 +90,7 @@ static struct rr* cert_parse(char *name, long ttl, int type, char *s)
         return bitch("bad key tag");
     rr->key_tag = key_tag;
 
-    if (isdigit(*s)) {
+    if (isdigit((unsigned char)*s)) {
         alg = extract_integer(&s, "algorithm", NULL);
         if (alg < 0)    return NULL;
         if (alg > 255)  return bitch("bad algorithm");

--- a/loc.c
+++ b/loc.c
@@ -64,7 +64,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
     deg = i;
     min = 0;
     sec = 0;
-    if (isdigit(*s)) {
+    if (isdigit((unsigned char)*s)) {
         i = extract_integer(&s, "minutes latitude", NULL);
         if (i < 0)
             return NULL;
@@ -72,7 +72,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
             return bitch("minutes latitude not in the range 0..59");
         min = i;
 
-        if (isdigit(*s)) { /* restricted floating point, starting with a digit */
+        if (isdigit((unsigned char)*s)) { /* restricted floating point, starting with a digit */
             if (extract_double(&s, "seconds latitude", &sec, 0) < 0)
                 return NULL;
             if (sec < 0 || sec > 59.999)
@@ -89,7 +89,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
     } else {
         return bitch("latitude: N or S is expected");
     }
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         return bitch("latitude: N or S is expected");
     }
     s = skip_white_space(s);
@@ -104,7 +104,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
     deg = i;
     min = 0;
     sec = 0;
-    if (isdigit(*s)) {
+    if (isdigit((unsigned char)*s)) {
         i = extract_integer(&s, "minutes longitude", NULL);
         if (i < 0)
             return NULL;
@@ -112,7 +112,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
             return bitch("minutes longitude not in the range 0..59");
         min = i;
 
-        if (isdigit(*s)) { /* restricted floating point, starting with a digit */
+        if (isdigit((unsigned char)*s)) { /* restricted floating point, starting with a digit */
             if (extract_double(&s, "seconds longitude", &sec, 0) < 0)
                 return NULL;
             if (sec < 0 || sec > 59.999)
@@ -129,7 +129,7 @@ static struct rr *loc_parse(char *name, long ttl, int type, char *s)
     } else {
         return bitch("longitude: E or W is expected");
     }
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         return bitch("longitude: E or W is expected");
     }
     s = skip_white_space(s);

--- a/main.c
+++ b/main.c
@@ -109,8 +109,8 @@ static char *process_directive(char *s)
     if (*(s+1) == 'O' && strncmp(s, "$ORIGIN", 7) == 0) {
         char *o;
         s += 7;
-        if (!isspace(*s)) {
-            if (isalnum(*s)) goto unrecognized_directive;
+        if (!isspace((unsigned char)*s)) {
+            if (isalnum((unsigned char)*s)) goto unrecognized_directive;
             return bitch("bad $ORIGIN format");
         }
         s = skip_white_space(s);
@@ -128,8 +128,8 @@ static char *process_directive(char *s)
         }
     } else if (*(s+1) == 'T' && strncmp(s, "$TTL", 4) == 0) {
         s += 4;
-        if (!isspace(*s)) {
-            if (isalnum(*s)) goto unrecognized_directive;
+        if (!isspace((unsigned char)*s)) {
+            if (isalnum((unsigned char)*s)) goto unrecognized_directive;
             return bitch("bad $TTL format");
         }
         s = skip_white_space(s);
@@ -149,8 +149,8 @@ static char *process_directive(char *s)
         char *lhs, *rdtype;
 
         s += 9;
-        if (!isspace(*s)) {
-            if (isalnum(*s)) goto unrecognized_directive;
+        if (!isspace((unsigned char)*s)) {
+            if (isalnum((unsigned char)*s)) goto unrecognized_directive;
             return bitch("bad $GENERATE format");
         }
         s = skip_white_space(s);
@@ -190,13 +190,13 @@ static char *process_directive(char *s)
         char *p, *f;
         char c;
         s += 8;
-        if (!isspace(*s)) {
-            if (isalnum(*s)) goto unrecognized_directive;
+        if (!isspace((unsigned char)*s)) {
+            if (isalnum((unsigned char)*s)) goto unrecognized_directive;
             return bitch("bad $INCLUDE format");
         }
         s = skip_white_space(s);
         p = s;
-        while (*s && !isspace(*s) && *s != ';')
+        while (*s && !isspace((unsigned char)*s) && *s != ';')
             s++;
         c = *s;
         *s = '\0';
@@ -221,7 +221,7 @@ static char *process_directive(char *s)
     } else {
 unrecognized_directive:
         s = d-1;
-        while (isalnum(*d)) d++;
+        while (isalnum((unsigned char)*d)) d++;
         *d = '\0';
         return bitch("unrecognized directive: %s", s);
     }
@@ -276,7 +276,7 @@ read_zone_file(void)
                 continue;
 
             s = file_info->buf;
-            if (!isspace(*s)) {
+            if (!isspace((unsigned char)*s)) {
                 /* <domain-name>, $INCLUDE, $ORIGIN */
                 if (*s == '$') {
                     process_directive(s);
@@ -298,7 +298,7 @@ read_zone_file(void)
             }
             if (G.default_ttl >= 0)
                 ttl = G.default_ttl;
-            if (isdigit(*s)) {
+            if (isdigit((unsigned char)*s)) {
                 ttl = extract_timevalue(&s, "TTL");
                 if (ttl < 0)
                     continue;
@@ -323,7 +323,7 @@ read_zone_file(void)
                 if (!class)
                     continue;
                 if (*class == 'i' && *(class+1) == 'n' && *(class+2) == 0) {
-                    if (isdigit(*s)) {
+                    if (isdigit((unsigned char)*s)) {
                         ttl = extract_timevalue(&s, "TTL");
                         if (ttl < 0)
                             continue;

--- a/naptr.c
+++ b/naptr.c
@@ -42,7 +42,7 @@ static struct rr *naptr_parse(char *name, long ttl, int type, char *s)
     if (text.length < 0)
         return NULL;
     for (i = 0; i < text.length; i++) {
-        if (!isalnum(text.data[i])) {
+        if (!isalnum((unsigned char)text.data[i])) {
             return bitch("flags contains illegal characters");
         }
     }

--- a/nsec.c
+++ b/nsec.c
@@ -133,7 +133,7 @@ void validate_nsec_chain(void)
         freeall_temp();
         s = rr->next_domain;
         t = name;
-        while (*s) *t++ = tolower(*s++);
+        while (*s) *t++ = tolower((unsigned char)*s++);
         *t = 0;
         rr_set = find_rr_set(T_NSEC, name);
         if (!rr_set) {

--- a/nsec3.c
+++ b/nsec3.c
@@ -65,7 +65,7 @@ static struct rr* nsec3_parse(char *name, long ttl, int type, char *s)
         rr->salt.length = 0;
         rr->salt.data = NULL;
         s++;
-        if (*s && !isspace(*s) && *s != ';' && *s != ')')
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')')
             return bitch("salt is not valid");
         s = skip_white_space(s);
     } else {

--- a/nsec3param.c
+++ b/nsec3param.c
@@ -58,7 +58,7 @@ static struct rr* nsec3param_parse(char *name, long ttl, int type, char *s)
         rr->salt.length = 0;
         rr->salt.data = NULL;
         s++;
-        if (*s && !isspace(*s) && *s != ';' && *s != ')')
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')')
             return bitch("salt is not valid");
         s = skip_white_space(s);
     } else {

--- a/rr.c
+++ b/rr.c
@@ -449,7 +449,7 @@ invalid:
     }
     if (*s++ != '#')
         goto invalid;
-    if (*s && !isspace(*s) && *s != ';' && *s != ')')
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')')
         goto invalid;
     s = skip_white_space(s);
     if (!s) return NULL;
@@ -841,7 +841,7 @@ int extract_algorithm(char **s, char *what)
     int alg;
     char *str_alg;
 
-    if (isdigit(**s)) {
+    if (isdigit((unsigned char)**s)) {
         alg = extract_integer(s, what, NULL);
         if (algorithm_type(alg) == ALG_UNSUPPORTED) {
             bitch("bad or unsupported algorithm %d", alg);

--- a/textparse.c
+++ b/textparse.c
@@ -26,7 +26,7 @@
 
 int empty_line_or_comment(char *s)
 {
-    while (isspace(*s)) s++;
+    while (isspace((unsigned char)*s)) s++;
     if (!*s) return 1;
     if (*s == ';')  return 1;
     return 0;
@@ -34,7 +34,7 @@ int empty_line_or_comment(char *s)
 
 char *skip_white_space(char *s)
 {
-    while (isspace(*s)) s++;
+    while (isspace((unsigned char)*s)) s++;
     if (*s == ';') {
         while (*s) s++;
     }
@@ -76,20 +76,20 @@ static char *extract_name_slow(char **input, char *what, int options)
     int d, l, ol;
 
     while (1) {
-        if (isalnum(*s) || *s == '_' || *s == '.' || *s == '-' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$')) {
+        if (isalnum((unsigned char)*s) || *s == '_' || *s == '.' || *s == '-' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$')) {
             if (t-buf >= 1022)
                 return bitch("name too long");
             *t++ = *s++;
         } else if (*s == '\\') {
             s++;
-            if (isdigit(*s)) {
+            if (isdigit((unsigned char)*s)) {
                 d = *s - '0';
                 s++;
-                if (!isdigit(*s))
+                if (!isdigit((unsigned char)*s))
                     return bitch("bad escape sequence");
                 d = d*10 + *s - '0';
                 s++;
-                if (!isdigit(*s))
+                if (!isdigit((unsigned char)*s))
                     return bitch("bad escape sequence");
                 d = d*10 + *s - '0';
                 s++;
@@ -114,7 +114,7 @@ static char *extract_name_slow(char **input, char *what, int options)
             break;
         }
     }
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         return bitch("%s is not valid", what);
     }
     *t = '\0';
@@ -154,7 +154,7 @@ static char *extract_name_slow(char **input, char *what, int options)
     if (!(options & KEEP_CAPITALIZATION)) {
         t = buf;
         while (*t) {
-            *t = tolower(*t);
+            *t = tolower((unsigned char)*t);
             t++;
         }
     }
@@ -173,7 +173,7 @@ char *extract_name(char **input, char *what, int options)
 
     if (*s == '@') {
         s++;
-        if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
             return bitch("literal @ in %s is not all by itself", what);
         }
         if (!file_info->current_origin) {
@@ -181,7 +181,7 @@ char *extract_name(char **input, char *what, int options)
         }
         r = quickstrdup(file_info->current_origin);
     } else {
-        if (!(isalnum(*s) || *s == '_' || *s == '.' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$'))) {
+        if (!(isalnum((unsigned char)*s) || *s == '_' || *s == '.' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$'))) {
             if (*s == '*') {
                 wildcard = 1;
             } else {
@@ -191,9 +191,9 @@ char *extract_name(char **input, char *what, int options)
             }
         }
         s++;
-        while (isalnum(*s) || *s == '.' || *s == '-' || *s == '_' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$'))
+        while (isalnum((unsigned char)*s) || *s == '.' || *s == '-' || *s == '_' || *s == '/' || ((options & DOLLAR_OK_IN_NAMES) && *s == '$'))
             s++;
-        if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
             if (*s == '\\')
                 return extract_name_slow(input, what, options);
             return bitch("%s is not valid", what);
@@ -226,7 +226,7 @@ char *extract_name(char **input, char *what, int options)
     if (!(options & KEEP_CAPITALIZATION)) {
         s = r;
         while (*s) {
-            *s = tolower(*s);
+            *s = tolower((unsigned char)*s);
             s++;
         }
     }
@@ -244,13 +244,13 @@ char *extract_label(char **input, char *what, void *is_temporary)
     char *r = NULL;
     char *end = NULL;
 
-    if (!isalpha(*s)) {
+    if (!isalpha((unsigned char)*s)) {
         return bitch("%s expected", what);
     }
     s++;
-    while (isalnum(*s))
+    while (isalnum((unsigned char)*s))
         s++;
-    if (*s && !isspace(*s)) {
+    if (*s && !isspace((unsigned char)*s)) {
         return bitch("%s is not valid", what);
     }
     if (!*s)    end = s;
@@ -270,7 +270,7 @@ char *extract_label(char **input, char *what, void *is_temporary)
     }
     s = r;
     while (*s) {
-        *s = tolower(*s);
+        *s = tolower((unsigned char)*s);
         s++;
     }
     return r;
@@ -283,14 +283,14 @@ long long extract_integer(char **input, char *what, const char *extra_delimiters
     char *end = NULL;
     char c;
 
-    if (!isdigit(*s)) {
+    if (!isdigit((unsigned char)*s)) {
         bitch("%s expected", what);
         return -1;
     }
     s++;
-    while (isdigit(*s))
+    while (isdigit((unsigned char)*s))
         s++;
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         if (!extra_delimiters || strchr(extra_delimiters, *s) == NULL) {
             bitch("%s is not valid", what);
             return -1;
@@ -320,9 +320,9 @@ int extract_double(char **input, char *what, double *val, int skip_m)
     char c;
     int saw_m = 0;
 
-    while (isdigit(*s) || *s == '+' || *s == '-' || *s == '.')
+    while (isdigit((unsigned char)*s) || *s == '+' || *s == '-' || *s == '.')
         s++;
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         if (skip_m && (*s == 'm' || *s == 'M')) {
             saw_m = 1;
         } else {
@@ -343,7 +343,7 @@ int extract_double(char **input, char *what, double *val, int skip_m)
 
     if (saw_m) {
         s++;
-        if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
             bitch("%s is not valid", what);
             return -1;
         }
@@ -364,36 +364,36 @@ long extract_timevalue(char **input, char *what)
     char *s = *input;
     int r = 0, acc = 0;
 
-    if (!isdigit(*s)) {
+    if (!isdigit((unsigned char)*s)) {
         bitch("%s expected", what);
         return -1;
     }
 next_component:
     r = 0;
-    while (isdigit(*s)) {
+    while (isdigit((unsigned char)*s)) {
         r *= 10;
         r += *s - '0';
         s++;
     }
-    if (tolower(*s) == 's') {
+    if (tolower((unsigned char)*s) == 's') {
         s++;
-    } else if (tolower(*s) == 'm') {
+    } else if (tolower((unsigned char)*s) == 'm') {
         r *= 60;
         s++;
-    } else if (tolower(*s) == 'h') {
+    } else if (tolower((unsigned char)*s) == 'h') {
         r *= 3600;
         s++;
-    } else if (tolower(*s) == 'd') {
+    } else if (tolower((unsigned char)*s) == 'd') {
         r *= 86400;
         s++;
-    } else if (tolower(*s) == 'w') {
+    } else if (tolower((unsigned char)*s) == 'w') {
         r *= 604800;
         s++;
     }
     acc += r;
-    if (isdigit(*s)) goto next_component;
+    if (isdigit((unsigned char)*s)) goto next_component;
 
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -415,66 +415,66 @@ long long extract_timestamp(char **input, char *what)
     long long epoch = 0;
     struct tm tm;
 
-    if (!isdigit(*s)) {
+    if (!isdigit((unsigned char)*s)) {
         bitch("%s expected", what);
         return -1;
     }
     year = year*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     year = year*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     year = year*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     year = year*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     month = month*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     month = month*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     day = day*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     day = day*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     hour = hour*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     hour = hour*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     minute = minute*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     minute = minute*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     second = second*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (!isdigit(*s)) goto looks_like_epoch;
+    if (!isdigit((unsigned char)*s)) goto looks_like_epoch;
     second = second*10 + *s - '0';
     epoch = epoch*10 + *s - '0';
     s++;
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -500,7 +500,7 @@ long long extract_timestamp(char **input, char *what)
     goto done;
 
 looks_like_epoch:
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -516,14 +516,14 @@ int extract_ipv4(char **input, char *what, struct in_addr *addr)
     char *s = *input;
     char c;
 
-    while (isdigit(*s) || *s == '.') {
+    while (isdigit((unsigned char)*s) || *s == '.') {
         s++;
     }
     if (s == *input) {
         bitch("%s is not valid", what);
         return -1;
     }
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -547,7 +547,7 @@ int extract_ipv6(char **input, char *what, struct in6_addr *addr)
     char *s = *input;
     char c;
 
-    while (isdigit(*s) || *s == ':' || *s == '.' ||
+    while (isdigit((unsigned char)*s) || *s == ':' || *s == '.' ||
           (*s >= 'a' && *s <= 'f') || (*s >= 'A' && *s <= 'F'))
     {
         s++;
@@ -556,7 +556,7 @@ int extract_ipv6(char **input, char *what, struct in6_addr *addr)
         bitch("%s is not valid", what);
         return -1;
     }
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -581,10 +581,10 @@ int extract_u64(char **input, char *what, uint64_t *r)
     uint8_t result = 0;
     unsigned u;
 
-    #define GETHEXBLOCK if (!isxdigit(*s)) { bitch("%s is not valid", what); return -1; } \
+    #define GETHEXBLOCK if (!isxdigit((unsigned char)*s)) { bitch("%s is not valid", what); return -1; } \
         u = 0; \
-        while (isxdigit(*s)) { \
-            if (isdigit(*s)) { \
+        while (isxdigit((unsigned char)*s)) { \
+            if (isdigit((unsigned char)*s)) { \
                 u = (u << 4) | (*s - '0'); \
             } else if (*s >= 'a' && *s <= 'f') { \
                 u = (u << 4) | (*s - 'a' + 10); \
@@ -606,7 +606,7 @@ int extract_u64(char **input, char *what, uint64_t *r)
     #undef GETHEXBLOCK
     #undef SKIPCOLON
 
-    if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+    if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
         bitch("%s is not valid", what);
         return -1;
     }
@@ -647,7 +647,7 @@ dump_binary_data(FILE *f, struct binary_data d)
         for (i = 0; i < 16 && mem_len > 0; i++, mem_len--, s++) {
             o[pos[i]] = hex[*s >> 4];
             o[pos[i]+1] = hex[*s & 0x0f];
-            o[51+i] = isprint(*s) ? *s : '.';
+            o[51+i] = isprint((unsigned char)*s) ? *s : '.';
         }
         fprintf(f, "%s", o);
     }
@@ -662,11 +662,11 @@ struct binary_data extract_base64_binary_data(char **input, char *what)
     int bl;
 
     while (s && *s) {
-        if (!isalnum(*s) && *s != '=' && *s != '+' && *s != '/') {
+        if (!isalnum((unsigned char)*s) && *s != '=' && *s != '+' && *s != '/') {
             bitch("%s expected", what);
             return r;
         }
-        while (isalnum(*s) || *s == '=' || *s == '+' || *s == '/') {
+        while (isalnum((unsigned char)*s) || *s == '=' || *s == '+' || *s == '/') {
             if (l64 >= 4095) {
                 bitch("%s is too long", what);
                 return r;
@@ -737,7 +737,7 @@ struct binary_data extract_text(char **input, char *what)
     int c;
 
     if (*s != '"') {
-        while (*s && !isspace(*s)) {
+        while (*s && !isspace((unsigned char)*s)) {
             o[l++] = *s++;
         }
         *input = skip_white_space(s);
@@ -758,9 +758,9 @@ more_text:
             if (*s == 0) {
                 bitch("bad backslash quoting of %s", what);
                 return r;
-            } else if (isdigit(*s)) {
+            } else if (isdigit((unsigned char)*s)) {
                 c = 0;
-                while (isdigit(*s)) {
+                while (isdigit((unsigned char)*s)) {
                     c = c*10 + *s - '0';
                     s++;
                 }
@@ -814,7 +814,7 @@ struct binary_data extract_hex_binary_data(char **input, char *what, int eat_whi
     if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
         s += 2;
     if (eat_whitespace == EXTRACT_DONT_EAT_WHITESPACE) {
-        while (isxdigit(*s)) {
+        while (isxdigit((unsigned char)*s)) {
             if (hl >= 4095) {
                 bitch("%s is too long", what);
                 return r;
@@ -823,18 +823,18 @@ struct binary_data extract_hex_binary_data(char **input, char *what, int eat_whi
             s++;
             hl++;
         }
-        if (*s && !isspace(*s) && *s != ';' && *s != ')') {
+        if (*s && !isspace((unsigned char)*s) && *s != ';' && *s != ')') {
             bitch("%s is not valid", what);
             return r;
         }
         *input = skip_white_space(s);
     } else if (eat_whitespace == EXTRACT_EAT_WHITESPACE) {
         while (s && *s) {
-            if (!isxdigit(*s)) {
+            if (!isxdigit((unsigned char)*s)) {
                 bitch("%s expected", what);
                 return r;
             }
-            while (isxdigit(*s)) {
+            while (isxdigit((unsigned char)*s)) {
                 if (hl >= 4095) {
                     bitch("%s is too long", what);
                     return r;
@@ -859,7 +859,7 @@ struct binary_data extract_hex_binary_data(char **input, char *what, int eat_whi
     memset(r.data, 0, r.length);
     for (hi = 0; hi < hl-hb; hi++) {
         r.data[hi/2] <<= 4;
-        r.data[hi/2] |= 0x0f & (isdigit(hex[hi+hb]) ? hex[hi+hb] - '0' : tolower(hex[hi+hb]) - 'a' + 10);
+        r.data[hi/2] |= 0x0f & (isdigit((unsigned char)hex[hi+hb]) ? hex[hi+hb] - '0' : tolower((unsigned char)hex[hi+hb]) - 'a' + 10);
     }
     return r;
 }

--- a/tlsa.c
+++ b/tlsa.c
@@ -105,7 +105,7 @@ not_a_prefixed_domain_name:
             return moan(rr->file_name, rr->line, "not a proper prefixed DNS domain name");
         }
         s++;
-        while (isdigit(*s)) {
+        while (isdigit((unsigned char)*s)) {
             port = port * 10  + *s - '0';
             s++;
         }
@@ -134,7 +134,7 @@ static void* smimea_validate_set(struct rr_set *rr_set)
 
         /* c93f1e400f26708f98cb19d936620da35eec8f72e57f9eec01c1afd6._smimecert.example.com. */
         s = named_rr->name;
-        while (isxdigit(*s)) {
+        while (isxdigit((unsigned char)*s)) {
             hash_len++;
             s++;
         }

--- a/x25.c
+++ b/x25.c
@@ -34,7 +34,7 @@ static struct rr *x25_parse(char *name, long ttl, int type, char *s)
     if (rr->psdn_address.length < 4)
         return bitch("PSDN-address too short");
     for (i = 0; i < rr->psdn_address.length; i++) {
-        if (!isdigit(rr->psdn_address.data[i]))
+        if (!isdigit((unsigned char)rr->psdn_address.data[i]))
             return bitch("PSDN-address contains non-digits");
     }
 


### PR DESCRIPTION
In other words, it must either be EOF or a value representable by an
unsigned char.  Here we simply cast all the arguments to these functions
to "unsigned char".
