### PR TITLE
Compile against openssl 1.1+ and with gcc-8

### DIFF
--- a/dnskey.c
+++ b/dnskey.c
@@ -157,6 +157,7 @@ int dnskey_build_pkey(struct rr_dnskey *rr)
         unsigned int e_bytes;
         unsigned char *pk;
         int l;
+        BIGNUM *n, *e;
 
         rsa = RSA_new();
         if (!rsa)
@@ -177,11 +178,15 @@ int dnskey_build_pkey(struct rr_dnskey *rr)
         if (l < e_bytes) /* public key is too short */
             goto done;
 
-        rsa->e = BN_bin2bn(pk, e_bytes, NULL);
+        e = BN_bin2bn(pk, e_bytes, NULL);
         pk += e_bytes;
         l -= e_bytes;
 
-        rsa->n = BN_bin2bn(pk, l, NULL);
+        n = BN_bin2bn(pk, l, NULL);
+        if (!e || !n)
+            goto done;
+
+        RSA_set0_key(rsa, n, e, NULL);
 
         pkey = EVP_PKEY_new();
         if (!pkey)

--- a/ipseckey.c
+++ b/ipseckey.c
@@ -93,17 +93,17 @@ static struct rr *ipseckey_parse(char *name, long ttl, int type, char *s)
 static char* ipseckey_human(struct rr *rrv)
 {
     RRCAST(ipseckey);
-    char s[1024], gw[1024];
+    char s[1024], gw[1000];
 
     switch (rr->gateway_type) {
     case 0:
         strcpy(gw, rr->gateway.gateway_none);
         break;
     case 1:
-        inet_ntop(AF_INET, &rr->gateway.gateway_ipv4, gw, 1024);
+        inet_ntop(AF_INET, &rr->gateway.gateway_ipv4, gw, sizeof(gw));
         break;
     case 2:
-        inet_ntop(AF_INET6, &rr->gateway.gateway_ipv6, gw, 1024);
+        inet_ntop(AF_INET6, &rr->gateway.gateway_ipv6, gw, sizeof(gw));
         break;
     case 3:
         strcpy(gw, rr->gateway.gateway_name);

--- a/nsec3checks.c
+++ b/nsec3checks.c
@@ -28,7 +28,7 @@
 static struct binary_data name2hash(char *name, struct rr *param)
 {
     struct rr_nsec3param *p = (struct rr_nsec3param *)param;
-    EVP_MD_CTX ctx;
+    EVP_MD_CTX *ctx;
     unsigned char md0[EVP_MAX_MD_SIZE];
     unsigned char md1[EVP_MAX_MD_SIZE];
     unsigned char *md[2];
@@ -45,26 +45,31 @@ static struct binary_data name2hash(char *name, struct rr *param)
 
     /* XXX Maybe use Init_ex and Final_ex for speed? */
 
-    EVP_MD_CTX_init(&ctx);
-    if (EVP_DigestInit(&ctx, EVP_sha1()) != 1)
+    ctx = EVP_MD_CTX_new();
+    if (ctx == NULL)
         return r;
-    digest_size = EVP_MD_CTX_size(&ctx);
-    EVP_DigestUpdate(&ctx, wire_name.data, wire_name.length);
-    EVP_DigestUpdate(&ctx, p->salt.data, p->salt.length);
-    EVP_DigestFinal(&ctx, md[mdi], NULL);
+    if (EVP_DigestInit(ctx, EVP_sha1()) != 1)
+        goto out;
+    digest_size = EVP_MD_CTX_size(ctx);
+    EVP_DigestUpdate(ctx, wire_name.data, wire_name.length);
+    EVP_DigestUpdate(ctx, p->salt.data, p->salt.length);
+    EVP_DigestFinal(ctx, md[mdi], NULL);
 
     for (i = 0; i < p->iterations; i++) {
-        if (EVP_DigestInit(&ctx, EVP_sha1()) != 1)
-            return r;
-        EVP_DigestUpdate(&ctx, md[mdi], digest_size);
+        if (EVP_DigestInit(ctx, EVP_sha1()) != 1)
+            goto out;
+
+        EVP_DigestUpdate(ctx, md[mdi], digest_size);
         mdi = (mdi + 1) % 2;
-        EVP_DigestUpdate(&ctx, p->salt.data, p->salt.length);
-        EVP_DigestFinal(&ctx, md[mdi], NULL);
+        EVP_DigestUpdate(ctx, p->salt.data, p->salt.length);
+        EVP_DigestFinal(ctx, md[mdi], NULL);
     }
 
     r.length = digest_size;
     r.data = getmem(digest_size);
     memcpy(r.data, md[mdi], digest_size);
+out:
+    EVP_MD_CTX_free(ctx);
     return r;
 }
 


### PR DESCRIPTION
First patch gets it compiled with gcc-8.
Second patch is updated patch initially made by FauxFaux. I addressed my own review by checking for possible NULL pointer and dropping the locking which is obsolete in openssl 1.1.